### PR TITLE
Upgrade sbt-structure plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -234,6 +234,8 @@ lazy val pluginPackagerCommunity =
           "launcher/sbt-structure-0.12.jar"),
         Library(Dependencies.sbtStructureExtractor013,
           "launcher/sbt-structure-0.13.jar"),
+        Library(Dependencies.sbtStructureExtractor100M4,
+          "launcher/sbt-structure-1-0-0-m4.jar"),
         Library(Dependencies.sbtLaunch,
           "launcher/sbt-launch.jar")
       )

--- a/project/BintrayJetbrains.scala
+++ b/project/BintrayJetbrains.scala
@@ -13,16 +13,21 @@ object BintrayJetbrains {
     val scalaTestFindersPatched  = jbBintrayResolver("scalatest-finders-patched", "scalatest", Resolver.ivyStylePatterns)
     val scalaPluginDeps  = jbBintrayResolver("scala-plugin-deps", "scala-plugin-deps", Resolver.ivyStylePatterns)
     val structureCore = jbSbtResolver("jb-structure-core", Resolver.ivyStylePatterns)
-    val structureExtractor012 = jbSbtResolver("jb-structure-extractor-0.12", Patterns.structureExtractor012)
-    val structureExtractor013 = jbSbtResolver("jb-structure-extractor-0.13", Patterns.structureExtractor013)
+    val structureExtractor012   = jbSbtResolver("jb-structure-extractor-0.12", Patterns.structureExtractor012)
+    val structureExtractor013   = jbSbtResolver("jb-structure-extractor-0.13", Patterns.structureExtractor013)
+    val structureExtractor100M4 = {
+      val defaultLocal = Resolver.defaultLocal
+      FileRepository("jb-structure-extractor-1.0.0-M4", defaultLocal.configuration, Patterns.structureExtractor100M4)
+    }
   }
 
   object Patterns {
-    val structureExtractor012 = sbt.Patterns(false, "[organisation]/[module]/scala_2.9.2/sbt_0.12/[revision]/[type]s/[artifact](-[classifier]).[ext]")
-    val structureExtractor013 = sbt.Patterns(false, "[organisation]/[module]/scala_2.10/sbt_0.13/[revision]/[type]s/[artifact](-[classifier]).[ext]")
+    val structureExtractor012   = sbt.Patterns(false, "[organisation]/[module]/scala_2.9.2/sbt_0.12/[revision]/[type]s/[artifact](-[classifier]).[ext]")
+    val structureExtractor013   = sbt.Patterns(false, "[organisation]/[module]/scala_2.10/sbt_0.13/[revision]/[type]s/[artifact](-[classifier]).[ext]")
+    val structureExtractor100M4 = sbt.Patterns(false, s"$${ivy.home}/local/[organisation]/[module]/scala_2.11/sbt_1.0.0-M4/[revision]/[type]s/[artifact](-[classifier]).[ext]")
   }
 
   val allResolvers = Seq(Resolvers.mavenPatched, Resolvers.structureCore,
-                         Resolvers.structureExtractor012, Resolvers.structureExtractor013,
+                         Resolvers.structureExtractor012, Resolvers.structureExtractor013, Resolvers.structureExtractor100M4,
                          Resolvers.scalaTestFindersPatched, Resolvers.scalaPluginDeps)
 }

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -73,11 +73,11 @@ object Dependencies {
   val macroParadise = "org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full
 
   val nailgun = "org.jetbrains" % "nailgun-patched" % "1.0.0"
-  val compilerInterfaceSources = "org.scala-sbt" % "compiler-bridge_2.10" % "1.0.0-M1" classifier "sources" intransitive ()
-  val compilerInterface = "org.scala-sbt" % "compiler-interface" % "1.0.0-M1" intransitive ()
+  val compilerInterfaceSources = "org.scala-sbt" % "compiler-bridge_2.10" % "1.0.0-M3" classifier "sources" intransitive ()
+  val compilerInterface = "org.scala-sbt" % "compiler-interface" % "1.0.0-M3" intransitive ()
   val bundledJline = "org.jetbrains" % "jline" % "1.0.0"
-  val zinc = "org.scala-sbt" % "zinc_2.11" % "1.0.0-M1"
-  val sbtInterface = "org.scala-sbt" % "util-interface" % "0.1.0-M12"
+  val zinc = "org.scala-sbt" % "zinc_2.11" % "1.0.0-M3"
+  val sbtInterface = "org.scala-sbt" % "util-interface" % "0.1.0-M13"
 }
 
 object DependencyGroups {

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
 
   val sbtStructureExtractor012 = "org.jetbrains" % "sbt-structure-extractor-0-12" % sbtStructureVersion
   val sbtStructureExtractor013 = "org.jetbrains" % "sbt-structure-extractor-0-13" % sbtStructureVersion
+  val sbtStructureExtractor100M4 = "org.jetbrains" % "sbt-structure-extractor-1-0-0-m4" % "0.1-SNAPSHOT"
   val sbtLaunch = "org.scala-sbt" % "sbt-launch" % sbtVersion
 
   val jamm = "com.github.jbellis" % "jamm" % "0.3.1"
@@ -26,7 +27,7 @@ object Dependencies {
   val scalaCompiler = "org.scala-lang" % "scala-compiler" % scalaVersion
   val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.0.2"
   val scalaParserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
-  val sbtStructureCore = "org.jetbrains" % "sbt-structure-core_2.11" % sbtStructureVersion
+  val sbtStructureCore = "org.jetbrains" % "sbt-structure-core_2.11" % "0.1-SNAPSHOT"
   val evoInflector = "org.atteo" % "evo-inflector" % "1.2"
   val scalatestFindersPatched = "org.scalatest" % "scalatest-finders-patched" % "0.9.8"
 
@@ -239,6 +240,7 @@ object DependencyGroups {
   val sbtRuntime = Seq(
     sbtStructureExtractor012,
     sbtStructureExtractor013,
+    sbtStructureExtractor100M4,
     sbtLaunch
   )
 }

--- a/src/org/jetbrains/plugins/scala/project/Versions.scala
+++ b/src/org/jetbrains/plugins/scala/project/Versions.scala
@@ -18,16 +18,13 @@ object Versions extends Versions {
 
   def loadScalaVersions = loadVersionsOf(Scala)
 
-  def loadSbtVersions = loadVersionsOf(Sbt) ++ loadVersionsOf(SbtMilestones)
+  def loadSbtVersions = loadVersionsOf(Sbt) :+ "1.0.0-M4"
 
   private object Scala extends Entity("http://repo1.maven.org/maven2/org/scala-lang/scala-compiler/",
     Version("2.8.0"), Seq("2.8.2", "2.9.3", "2.10.4", "2.11.5"))
 
   private object Sbt extends Entity("http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/launcher/",
     Version("0.12.0"), Seq("0.12.4", "0.13.7"))
-
-  private object SbtMilestones extends Entity("https://repo1.maven.org/maven2/org/scala-sbt/launcher/",
-    Version("1.0.0-M3"), Seq("1.0.0-M3"))
 }
 
 trait Versions {

--- a/src/org/jetbrains/sbt/project/structure/SbtRunner.scala
+++ b/src/org/jetbrains/sbt/project/structure/SbtRunner.scala
@@ -46,7 +46,7 @@ class SbtRunner(vmExecutable: File, vmOptions: Seq[String], environment: Map[Str
       val message = s"SBT $SinceSbtVersion+ required. Please update the project definition"
       Left(new UnsupportedOperationException(message))
     } else {
-      read1(directory, majorSbtVersion, options, listener)
+      read1(directory, "1-0-0-m4", options, listener)
     }
   }
 
@@ -62,10 +62,10 @@ class SbtRunner(vmExecutable: File, vmOptions: Seq[String], environment: Map[Str
 
     usingTempFile("sbt-structure", Some(".xml")) { structureFile =>
       val sbtCommands = Seq(
-        s"""set shellPrompt := { _ => "" }""",
+        s"""set shellPrompt := { _ => "$pluginFile" }""",
         s"""set SettingKey[Option[File]]("sbt-structure-output-file") in Global := Some(file("${path(structureFile)}"))""",
         s"""set SettingKey[String]("sbt-structure-options") in Global := "${options}" """,
-        s"""apply -cp "${path(pluginFile)}" org.jetbrains.sbt.CreateTasks""",
+        s"""apply -cp "${path(pluginFile)}" sbt.CreateTasks""",
         s"""*/*:dump-structure""",
         s"""exit""")
 


### PR DESCRIPTION
With these changes I'm able to compile a very simple Scala file (`object A`):

``` scala
> jpsPlugin/console
[info] Starting scala interpreter...
[info] 
Welcome to Scala version 2.11.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_60).
Type in expressions to have them evaluated.
Type :help for more information.

scala> :pas
// Entering paste mode (ctrl-D to finish)

import org.jetbrains.jps.incremental.scala.data.SbtData
import org.jetbrains.jps.incremental.scala.local.CompilerFactoryImpl
import org.jetbrains.jps.incremental.scala.data.CompilerData
import org.jetbrains.jps.incremental.scala.data.CompilerJars
import org.jetbrains.jps.incremental.scala.model.IncrementalityType
import org.jetbrains.jps.incremental.scala.model.CompileOrder
import org.jetbrains.jps.incremental.scala.DummyClient
import org.jetbrains.jps.incremental.scala.local.LocalServer
import sbt.internal.inc.{AnalysisStore, FileBasedStore}
import org.jetbrains.jps.incremental.scala.data.CompilationData
import java.io.File

object ASUtil {
  def createAnalysisStore(cacheFile: File): AnalysisStore = {
    val store = FileBasedStore(cacheFile)
    AnalysisStore.sync(AnalysisStore.cached(store))
  }
}

val utilInterface = new File("/Users/martin/.ivy2/cache/org.scala-sbt/util-interface/jars/util-interface-0.1.0-M13.jar")
val compilerInterface = new File("/Users/martin/.ivy2/cache/org.scala-sbt/compiler-interface/jars/compiler-interface-1.0.0-M3.jar")
val bridgeSource = new File("/Users/martin/Downloads/compiler-bridge_2.11-1.0.0-M3-sources.jar")
val javaClassVersion = System.getProperty("java.class.version")
val temp = new File("/Users/martin/Desktop/intellij-temp")
val sbtData = new SbtData(utilInterface, compilerInterface, bridgeSource, temp, javaClassVersion)
val factory = new CompilerFactoryImpl(sbtData)
val libraryJar = new File("/Users/martin/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.11.8.jar")
val compilerJar = new File("/Users/martin/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.11.8.jar")
val reflectJar = new File("/Users/martin/.ivy2/cache/org.scala-lang/scala-reflect/jars/scala-reflect-2.11.8.jar")
val compilerJars = CompilerJars(libraryJar, compilerJar, reflectJar :: Nil)
val compilerData = CompilerData(Some(compilerJars), None, IncrementalityType.SBT)
val client = new DummyClient
val compiler = factory.createCompiler(compilerData, client, ASUtil.createAnalysisStore)
val cacheFile = new File(temp, "inc_compile")
val source = new File(temp, "A.scala")
val compilationData = CompilationData(source :: Nil, libraryJar :: compilerJar :: reflectJar :: Nil, temp, Nil, Nil, CompileOrder.Mixed, cacheFile, Map(), Nil, None)


// Exiting paste mode, now interpreting.

import org.jetbrains.jps.incremental.scala.data.SbtData
import org.jetbrains.jps.incremental.scala.local.CompilerFactoryImpl
import org.jetbrains.jps.incremental.scala.data.CompilerData
import org.jetbrains.jps.incremental.scala.data.CompilerJars
import org.jetbrains.jps.incremental.scala.model.IncrementalityType
import org.jetbrains.jps.incremental.scala.model.CompileOrder
import org.jetbrains.jps.incremental.scala.DummyClient
import org.jetbrains.jps.incremental.scala.local.LocalServer
import sbt.internal.inc.{AnalysisStore, FileBasedStore}
import org.jetbrains.jps.incremental.scala.data.CompilationData
import java.io.File
defined object ASUtil
utilInterface: java.io.File = /Users/martin/.ivy2/cache/org.scala-sbt/util-interface/jars/util-interface-0.1.0-M13.jar
compilerInterface: java...
scala> compiler.compile(compilationData, client)

scala> 
zsh: suspended  sbt
wip/upgrade-structure✔ intellij-scala ❯ ls /Users/martin/Desktop/intellij-temp                                                                                                 
A$.class  A.class  A.scala  compiler-interface-2.11.8-52.0.jar  inc_compile
wip/upgrade-structure✔ intellij-scala ❯ tail /Users/martin/Desktop/intellij-temp/inc_compile                                                                                   rO0ABXNyABd4c2J0aS5hcGkuQW5hbHl6ZWRDbGFzczhW4g4MI+wzAgAGSQAHYXBpSGFzaFoACGhhc01hY3JvTAADYXBpdAAWTHhzYnRpL2FwaS9Db21wYW5pb25zO0wAC2NvbXBpbGF0aW9udAAXTHhzYnRpL2FwaS9Db21waWxhdGlvbjtMAARuYW1ldAASTGphdmEvbGFuZy9TdHJpbmc7TAAKbmFtZUhhc2hlc3QAFkx4c2J0aS9hcGkvTmFtZUhhc2hlczt4cN8AYbUAc3IAFHhzYnRpLmFwaS5Db21wYW5pb25zZX9P15J8biMCAAJMAAhjbGFzc0FwaXQAFUx4c2J0aS9hcGkvQ2xhc3NMaWtlO0wACW9iamVjdEFwaXEAfgAHeHBzcgATeHNidGkuYXBpLkNsYXNzTGlrZa+Y1m0NEiPBAgAHWwAVY2hpbGRyZW5PZlNlYWxlZENsYXNzdAARW0x4c2J0aS9hcGkvVHlwZTtMAA5kZWZpbml0aW9uVHlwZXQAGkx4c2J0aS9hcGkvRGVmaW5pdGlvblR5cGU7WwAQc2F2ZWRBbm5vdGF0aW9uc3QAE1tMamF2YS9sYW5nL1N0cmluZztMAAhzZWxmVHlwZXQAEEx4c2J0aS9hcGkvTGF6eTtMAAlzdHJ1Y3R1cmVxAH4ADUwACHRvcExldmVsdAATTGphdmEvbGFuZy9Cb29sZWFuO1sADnR5cGVQYXJhbWV0ZXJzdAAaW0x4c2J0aS9hcGkvVHlwZVBhcmFtZXRlcjt4cgAUeHNidGkuYXBpLkRlZmluaXRpb24QR+VY42UqkgIABEwABmFjY2Vzc3QAEkx4c2J0aS9hcGkvQWNjZXNzO1sAC2Fubm90YXRpb25zdAAXW0x4c2J0aS9hcGkvQW5ub3RhdGlvbjtMAAltb2RpZmllcnN0ABVMeHNidGkvYXBpL01vZGlmaWVycztMAARuYW1lcQB+AAN4cHNyABB4c2J0aS5hcGkuUHVibGljulg9rmwtYEICAAB4cgAQeHNidGkuYXBpLkFjY2Vzc+/wezyso1nJAgAAeHB1cgAXW0x4c2J0aS5hcGkuQW5ub3RhdGlvbjvrl+sZEPaNSAIAAHhwAAAAAHNyABN4c2J0aS5hcGkuTW9kaWZpZXJzl+dh3BMme7MCAAFCAAVmbGFnc3hwAHQAAUF1cgARW0x4c2J0aS5hcGkuVHlwZTt0/6Vae/npQQIAAHhwAAAAAH5yABh4c2J0aS5hcGkuRGVmaW5pdGlvblR5cGUAAAAAAAAAABIAAHhyAA5qYXZhLmxhbmcuRW51bQAAAAAAAAAAEgAAeHB0AAhDbGFzc0RlZnVyABNbTGphdmEubGFuZy5TdHJpbmc7rdJW5+kde0cCAAB4cAAAAABzcgAheHNidGkuYXBpLkFic3RyYWN0TGF6eSRTdHJpY3RMYXp5DWYcaykWKrgCAAFMAAV2YWx1ZXQAEkxqYXZhL2xhbmcvT2JqZWN0O3hwc3IAE3hzYnRpLmFwaS5FbXB0eVR5cGW8/Z5GSTuJJAIAAHhyABR4c2J0aS5hcGkuU2ltcGxlVHlwZT3lrmniSFLkAgAAeHIADnhzYnRpLmFwaS5UeXBluC8OaKJZJVUCAAB4cHNxAH4AJXNyABN4c2J0aS5hcGkuU3RydWN0dXJlpkJpfB7JpDECAANMAAhkZWNsYXJlZHEAfgANTAAJaW5oZXJpdGVkcQB+AA1MAAdwYXJlbnRzcQB+AA14cQB+ACpzcQB+ACV1cgAcW0x4c2J0aS5hcGkuQ2xhc3NEZWZpbml0aW9uO9jNZAwIghGaAgAAeHAAAAAAc3EAfgAldXEAfgAwAAAAAHNxAH4AJXVxAH4AHQAAAABzcgARamF2YS5sYW5nLkJvb2xlYW7NIHKA1Zz67gIAAVoABXZhbHVleHABdXIAGltMeHNidGkuYXBpLlR5cGVQYXJhbWV0ZXI72W0mDyid8rYCAAB4cAAAAABzcQB+AAlzcQB+ABV1cQB+ABgAAAAAc3EAfgAaAHQAAUF1cQB+AB0AAAAAfnEAfgAfdAAGTW9kdWxldXEAfgAjAAAAAHNxAH4AJXEAfgArc3EAfgAlc3EAfgAtc3EAfgAldXEAfgAwAAAAAHNxAH4AJXVxAH4AMAAAAABzcQB+ACV1cQB+AB0AAAACc3IAFHhzYnRpLmFwaS5Qcm9qZWN0aW9uFjroJdQ6GJICAAJMAAJpZHEAfgADTAAGcHJlZml4dAAWTHhzYnRpL2FwaS9TaW1wbGVUeXBlO3hxAH4AKXQABk9iamVjdHNyABN4c2J0aS5hcGkuU2luZ2xldG9uzZpLOdC54UECAAFMAARwYXRodAAQTHhzYnRpL2FwaS9QYXRoO3hxAH4AKXNyAA54c2J0aS5hcGkuUGF0aAomSyACwlYhAgABWwAKY29tcG9uZW50c3QAGltMeHNidGkvYXBpL1BhdGhDb21wb25lbnQ7eHB1cgAaW0x4c2J0aS5hcGkuUGF0aENvbXBvbmVudDtD2gl0LWcWdAIAAHhwAAAAA3NyAAx4c2J0aS5hcGkuSWQ8cUcnzUA2xAIAAUwAAmlkcQB+AAN4cgAXeHNidGkuYXBpLlBhdGhDb21wb25lbnQANZM+f8Nk6wIAAHhwdAAEamF2YXNxAH4AWHQABGxhbmdzcgAOeHNidGkuYXBpLlRoaXPbCe2mzFpAXAIAAHhxAH4AWXNxAH4ATHQAA0FueXNxAH4AUHNxAH4AU3VxAH4AVgAAAAJzcQB+AFh0AAVzY2FsYXEAfgBfcQB+ADd1cQB+ADgAAAAAc3IAFXhzYnRpLmFwaS5Db21waWxhdGlvbsSZKDhOwNOBAgACSgAJc3RhcnRUaW1lWwAHb3V0cHV0c3QAGltMeHNidGkvYXBpL091dHB1dFNldHRpbmc7eHAAAAFVDGON9HVyABpbTHhzYnRpLmFwaS5PdXRwdXRTZXR0aW5nO39qwvOnh6VCAgAAeHAAAAABc3IAF3hzYnRpLmFwaS5PdXRwdXRTZXR0aW5nMr05Wuk6p1ACAAJMAA9vdXRwdXREaXJlY3RvcnlxAH4AA0wAD3NvdXJjZURpcmVjdG9yeXEAfgADeHB0ACMvVXNlcnMvbWFydGluL0Rlc2t0b3AvaW50ZWxsaWotdGVtcHQAAS9xAH4AHHNyABR4c2J0aS5hcGkuTmFtZUhhc2hlc1O2qmBQD+KvAgACWwAPaW1wbGljaXRNZW1iZXJzdAAVW0x4c2J0aS9hcGkvTmFtZUhhc2g7WwAOcmVndWxhck1lbWJlcnNxAH4AcnhwdXIAFVtMeHNidGkuYXBpLk5hbWVIYXNoO7O2vsBBbM5tAgAAeHAAAAAAdXEAfgB0AAAAFHNyABJ4c2J0aS5hcGkuTmFtZUhhc2hvG4ZSCZgwZQIAAkkABGhhc2hMAARuYW1lcQB+AAN4cAsrwhd0AAZub3RpZnlzcQB+AHfQw+wSdAAEd2FpdHNxAH4Ad7FpcQl0AA0kYXNJbnN0YW5jZU9mc3EAfgB32gHnT3QABmVxdWFsc3NxAH4Ad8EkuOZ0AAxhc0luc3RhbmNlT2ZzcQB+AHe4H3N7dAAMc3luY2hyb25pemVkc3EAfgB3VmUhmXEAfgA+c3EAfgB3YNPlF3QADSRpc0luc3RhbmNlT2ZzcQB+AHccB9didAAJbm90aWZ5QWxsc3EAfgB35xLDpXQADGlzSW5zdGFuY2VPZnNxAH4Ad0rpdfV0AAI9PXNxAH4Ad79qJz50AAVjbG9uZXNxAH4AdzniiQp0AAh0b1N0cmluZ3NxAH4Ad+HwdnB0AAIhPXNxAH4Adzp/W590AAhnZXRDbGFzc3NxAH4Ad83CPeR0AAJuZXNxAH4Adyc2pKp0AAJlcXNxAH4Ad7O1i4V0AAIjI3NxAH4Ad7oulrR0AAhmaW5hbGl6ZXNxAH4Ad4xxdAh0AAhoYXNoQ29kZQ==
external apis:
0 items
source infos:
1 items
file:/Users/martin/Desktop/intellij-temp/A.scala -> 
AAAAAAAAAAA=
compilations:
1 items
0 -> rO0ABXNyABV4c2J0aS5hcGkuQ29tcGlsYXRpb27EmSg4TsDTgQIAAkoACXN0YXJ0VGltZVsAB291dHB1dHN0ABpbTHhzYnRpL2FwaS9PdXRwdXRTZXR0aW5nO3hwAAABVQxjjfR1cgAaW0x4c2J0aS5hcGkuT3V0cHV0U2V0dGluZzt/asLzp4elQgIAAHhwAAAAAXNyABd4c2J0aS5hcGkuT3V0cHV0U2V0dGluZzK9OVrpOqdQAgACTAAPb3V0cHV0RGlyZWN0b3J5dAASTGphdmEvbGFuZy9TdHJpbmc7TAAPc291cmNlRGlyZWN0b3J5cQB+AAZ4cHQAIy9Vc2Vycy9tYXJ0aW4vRGVza3RvcC9pbnRlbGxpai10ZW1wdAABLw==
```

I can also compile and run simple projects in IntelliJ with incrementality type set to sbt.

It requires a locally published version of [sbt-structure for sbt 1.0](https://github.com/sbt/sbt-structure/tree/sbt-1.0.0) (in IntelliJ the right pane named "SBT" shows the different projects)
